### PR TITLE
Simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright  2017 by Jeffrey C. Ollie <jeff@ocjtech.us>
+# Copyright © 2017 by Jeffrey C. Ollie <jeff@ocjtech.us>
 #
 # This file is part of OpenHAB Exporter.
 #
@@ -19,6 +19,7 @@
 FROM python:3
 MAINTAINER Jeffrey C. Ollie <jeff@ocjtech.us>
 
+ENV LANG C.UTF-8
 WORKDIR /usr/src/app
 
 COPY requirements.txt .
@@ -27,5 +28,6 @@ COPY setup.py .
 COPY src src
 RUN python setup.py install
 
+EXPOSE 9266
 
 ENTRYPOINT [ "openhab_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+COPY setup.py .
+COPY src src
+RUN python setup.py install
 
-COPY src/* .
 
-CMD [ "python", "cli.py" ]
+ENTRYPOINT [ "openhab_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,23 @@
+# Copyright  2017 by Jeffrey C. Ollie <jeff@ocjtech.us>
+#
+# This file is part of OpenHAB Exporter.
+#
+# OpenHAB Exporter is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# OpenHAB Exporter is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenHAB Exporter.  If not, see
+# <http://www.gnu.org/licenses/>.
+
 FROM python:3
-MAINTAINER Alex Laties <alex@laties.info>
+MAINTAINER Jeffrey C. Ollie <jeff@ocjtech.us>
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,11 @@
-# Copyright © 2017 by Jeffrey C. Ollie <jeff@ocjtech.us>
-#
-# This file is part of OpenHAB Exporter.
-#
-# OpenHAB Exporter is free software: you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# OpenHAB Exporter is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with OpenHAB Exporter.  If not, see
-# <http://www.gnu.org/licenses/>.
+FROM python:3
+MAINTAINER Alex Laties <alex@laties.info>
 
-FROM registry.fedoraproject.org/fedora:26
+WORKDIR /usr/src/app
 
-ENV LANG C.UTF-8
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-RUN dnf -y update --disablerepo=* --enablerepo=fedora --enablerepo=updates --enablerepo=updates-testing
-RUN dnf -y install python3 python3-devel python3-virtualenv gcc redhat-rpm-config openssl-devel libffi-devel
-RUN virtualenv-3 /opt/openhab_exporter
-RUN /opt/openhab_exporter/bin/pip install --upgrade pip
-RUN /opt/openhab_exporter/bin/pip install --upgrade setuptools
-RUN /opt/openhab_exporter/bin/pip install --upgrade 'Twisted[tls]' 'arrow'
-RUN dnf -y remove python3-devel python3-virtualenv gcc redhat-rpm-config openssl-devel libffi-devel
-RUN rm -rf /usr/share/doc/* /usr/share/man/* /var/cache/dnf/* /tmp/*
+COPY src/* .
 
-COPY setup.py /src/setup.py
-COPY src /src/src
-
-RUN cd /src && /opt/openhab_exporter/bin/python setup.py install
-RUN rm -rf /src
-
-EXPOSE 9266
-
-ENTRYPOINT ["/opt/openhab_exporter/bin/openhab_exporter"]
+CMD [ "python", "cli.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Twisted[tls]
+arrow


### PR DESCRIPTION
This change punts complexity in the dockerfile  upstream to make building and deploying `openhab_exporter` simpler to understand given a sane python 3 environment.

This removes the responsibility of producing a sane python3/pip-based build environment from the dockerfile and punts it to the upstream [python project dockerfile](https://hub.docker.com/_/python/).

This reduces the likelihood of failure in building an image due to wonkiness in `dnf`.

In testing on my puny personal server, this change reduces average clean build times from 6+ minutes to 1 minute and reduces average image from 892MB to 727MB.