### PR TITLE
Refactor Dockerfile to take up less space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,25 +16,20 @@
 # along with OpenHAB Exporter.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-FROM registry.fedoraproject.org/fedora:26
+FROM python:3-alpine
+LABEL maintainer="Jeffrey C. Ollie <jeff@ocjtech.us>"
 
 ENV LANG C.UTF-8
-
-RUN dnf -y update --disablerepo=* --enablerepo=fedora --enablerepo=updates --enablerepo=updates-testing
-RUN dnf -y install python3 python3-devel python3-virtualenv gcc redhat-rpm-config openssl-devel libffi-devel
-RUN virtualenv-3 /opt/openhab_exporter
-RUN /opt/openhab_exporter/bin/pip install --upgrade pip
-RUN /opt/openhab_exporter/bin/pip install --upgrade setuptools
-RUN /opt/openhab_exporter/bin/pip install --upgrade 'Twisted[tls]' 'arrow'
-RUN dnf -y remove python3-devel python3-virtualenv gcc redhat-rpm-config openssl-devel libffi-devel
-RUN rm -rf /usr/share/doc/* /usr/share/man/* /var/cache/dnf/* /tmp/*
 
 COPY setup.py /src/setup.py
 COPY src /src/src
 
-RUN cd /src && /opt/openhab_exporter/bin/python setup.py install
-RUN rm -rf /src
+RUN apk add --no-cache alpine-sdk libffi-dev openssl-dev && \
+	pip install 'Twisted[tls]' 'arrow' && \
+	cd /src && python setup.py install && \
+	rm -rf /src && \
+	apk del alpine-sdk
 
 EXPOSE 9266
 
-ENTRYPOINT ["/opt/openhab_exporter/bin/openhab_exporter"]
+ENTRYPOINT ["openhab_exporter"]


### PR DESCRIPTION
Using python:alpine instead of Fedora, chaining RUN statements and not using virtualenv in an already virtualized Docker container saves ~346MB of image size.

This makes the image lighter to download and use in a space-constrained environment. Total new image size is `149MB`, functionality should stay roughly the same (from the outside).