### PR TITLE
Add cargo to Dockerfile for cryptography library dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG C.UTF-8
 COPY setup.py /src/setup.py
 COPY src /src/src
 
-RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev && \
+RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev cargo&& \
   pip install 'Twisted[tls]' 'arrow' && \
   cd /src && python setup.py install && \
   rm -rf /src && \


### PR DESCRIPTION
I was recently unable to build the image as-is due to the cryptography library now having dependencies on Rust. I was able to get the build working by adding cargo to the Alpine image.